### PR TITLE
Randomize promo on home, blog detail, and rating detail pages

### DIFF
--- a/app/artiRating/[slug]/page.tsx
+++ b/app/artiRating/[slug]/page.tsx
@@ -12,7 +12,7 @@ import Slider from "@/app/components/slider/Slider";
 import { extractVideoID } from "@/app/helpers/videoHelper";
 import { notFound } from "next/navigation";
 import { RatingItem } from "@/app/components/filter/types";
-import PromoCodeHondenShop from "@/app/components/promo/PromoCodeHondenShop";
+import RandomPromo from "@/app/components/promo/RandomPromo";
 import BackButton from "@/app/components/backButton/BackButton";
 import PartnerBanner from "@/app/components/partnerBanner/PartnerBanner";
 
@@ -225,7 +225,7 @@ const RatingDetail = async ({ params }: { params: Promise<RatingParams> }) => {
         {bannerPartner ? (
           <PartnerBanner partner={bannerPartner} />
         ) : (
-          <PromoCodeHondenShop />
+          <RandomPromo />
         )}
       </div>
     </div>

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -7,7 +7,7 @@ import MediaWithText from "@/app/components/blogItem/MediaWithText";
 import Disclaimer from "@/app/components/blogItem/Disclaimer";
 import ShareOnSocials from "@/app/components/blogItem/ShareOnSocials";
 import { notFound } from "next/navigation";
-import PromoCodeHondenShop from "@/app/components/promo/PromoCodeHondenShop";
+import RandomBlogPromo from "@/app/components/promo/RandomBlogPromo";
 import BackButton from "@/app/components/backButton/BackButton";
 import HondenShopBanner from "@/app/components/hondenShopBanner/HondenShopBanner";
 import PartnerBanner from "@/app/components/partnerBanner/PartnerBanner";
@@ -179,7 +179,7 @@ const BlogDetail = async ({ params }: BlogDetailProps) => {
       </div>
       <Disclaimer />
       <div className="w-full max-w-[1200px] mb-4 mt-4">
-        <PromoCodeHondenShop />
+        <RandomBlogPromo />
       </div>
     </div>
   );

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -7,7 +7,7 @@ import MediaWithText from "@/app/components/blogItem/MediaWithText";
 import Disclaimer from "@/app/components/blogItem/Disclaimer";
 import ShareOnSocials from "@/app/components/blogItem/ShareOnSocials";
 import { notFound } from "next/navigation";
-import RandomBlogPromo from "@/app/components/promo/RandomBlogPromo";
+import RandomPromo from "@/app/components/promo/RandomPromo";
 import BackButton from "@/app/components/backButton/BackButton";
 import HondenShopBanner from "@/app/components/hondenShopBanner/HondenShopBanner";
 import PartnerBanner from "@/app/components/partnerBanner/PartnerBanner";
@@ -179,7 +179,7 @@ const BlogDetail = async ({ params }: BlogDetailProps) => {
       </div>
       <Disclaimer />
       <div className="w-full max-w-[1200px] mb-4 mt-4">
-        <RandomBlogPromo />
+        <RandomPromo />
       </div>
     </div>
   );

--- a/app/components/promo/RandomBlogPromo.tsx
+++ b/app/components/promo/RandomBlogPromo.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import PromoCodeHondenShop from "./PromoCodeHondenShop";
+import PromoCodeBellaDuke from "./PromoCodeBellaDuke";
+
+const RandomBlogPromo = () => {
+  const [showBella, setShowBella] = useState(false);
+
+  useEffect(() => {
+    setShowBella(Math.random() < 0.5);
+  }, []);
+
+  return showBella ? <PromoCodeBellaDuke /> : <PromoCodeHondenShop />;
+};
+
+export default RandomBlogPromo;

--- a/app/components/promo/RandomPromo.tsx
+++ b/app/components/promo/RandomPromo.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import PromoCodeHondenShop from "./PromoCodeHondenShop";
 import PromoCodeBellaDuke from "./PromoCodeBellaDuke";
 
-const RandomBlogPromo = () => {
+const RandomPromo = () => {
   const [showBella, setShowBella] = useState(false);
 
   useEffect(() => {
@@ -14,4 +14,4 @@ const RandomBlogPromo = () => {
   return showBella ? <PromoCodeBellaDuke /> : <PromoCodeHondenShop />;
 };
 
-export default RandomBlogPromo;
+export default RandomPromo;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 import { getFeaturedBlog, getFeaturedItem, getFeaturedPartners, getPartnerFileUrl } from "./pocketbase/pocketbase";
 import FeaturedBlog from "./components/featured/FeaturedBlog";
 import FeaturedRating from "./components/featured/FeaturedRating";
-import PromoCode from "./components/promo/PromoCodeHondenShop";
+import RandomPromo from "./components/promo/RandomPromo";
 import { FaDog, FaHeart, FaStar } from "react-icons/fa";
 import Image from "next/image";
 import Link from "next/link";
@@ -182,7 +182,7 @@ export default async function Home() {
           </div>
 
           <div className="my-16 anim-fade-up">
-            <PromoCode />
+            <RandomPromo />
           </div>
 
           {/* Category explorer */}


### PR DESCRIPTION
## Summary
- New `RandomPromo` client component that picks between Hondenshop and Bella & Duke promos on each page load (50/50)
- SSR renders Hondenshop as default, so the page works without JS and Google sees a promo
- On hydration the client may swap to Bella & Duke
- Applied to: home (`/`), blog detail (`/blog/[slug]`), rating detail (`/artiRating/[slug]`)
- `/artiActie` keeps both promos shown side by side (that's the dedicated promo overview)

## Test plan
- [ ] Open `/`, reload a few times, confirm sometimes Hondenshop, sometimes Bella & Duke shows in the promo slot
- [ ] Same on `/blog/welk-kauwbot-puppy` and `/artiRating/kong-easy-treat`
- [ ] Confirm `/artiActie` still shows both promos under each other
- [ ] Confirm no hydration warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)